### PR TITLE
jenkinsx-groovy-deployment to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,4 +18,4 @@ dependencies:
   version: 2.3.58
 - name: jenkinsx-groovy-deployment
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.2


### PR DESCRIPTION
Promote jenkinsx-groovy-deployment to version 0.0.2